### PR TITLE
[Duplicate] Updated launch library to use current IOCTls and gmem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
 
 [[package]]
 name = "kvm-bindings"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c1030d8ce8a7ac5797738f98d6e16450d2ddd298b4555c492009108822d3bd"
+checksum = "2efe3f1a4437bffe000e6297a593b98184213cd27486776c335f95ab53d48e3a"
 dependencies = [
  "vmm-sys-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,5 +75,5 @@ rdrand = { version = "^0.8", optional = true }
 kvm-ioctls = ">=0.16"
 
 [dev-dependencies]
-kvm-bindings = ">=0.7"
+kvm-bindings = ">=0.9.1"
 serial_test = "3.0"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-
+//comment
 fn main() {
     use std::path::Path;
 

--- a/src/launch/linux/mod.rs
+++ b/src/launch/linux/mod.rs
@@ -8,3 +8,6 @@ pub(crate) mod sev;
 
 #[cfg(feature = "snp")]
 pub(crate) mod snp;
+
+#[cfg(all(feature = "sev", feature = "snp"))]
+pub(crate) mod shared;

--- a/src/launch/linux/shared.rs
+++ b/src/launch/linux/shared.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! SEV and SEV-SNP shared types for interacting with the KVM SEV guest management API.
+
+/// Structure passed into KVM_SEV_INIT2 command.
+#[derive(Default)]
+#[repr(C, packed)]
+pub struct Init2 {
+    /// Initial value of features field in VMSA. (Must be 0 for SEV)
+    vmsa_features: u64,
+
+    /// Always set to 0
+    flags: u32,
+
+    /// Maximum guest GHCB version allowed. (Currently 0 for SEV and 1 for SEV-ES and SEV-SNP)
+    ghcb_version: u16,
+
+    pad1: u16,
+
+    pad2: [u32; 8],
+}
+
+impl Init2 {
+    /// Default INIT2 values for SEV
+    pub fn init_default_sev() -> Self {
+        Self {
+            vmsa_features: 0,
+            flags: 0,
+            ghcb_version: 0,
+            pad1: Default::default(),
+            pad2: Default::default(),
+        }
+    }
+
+    /// Default INIT2 values for SEV-ES
+    pub fn init_default_es() -> Self {
+        Self {
+            vmsa_features: 0x1,
+            flags: 0,
+            ghcb_version: 1,
+            pad1: Default::default(),
+            pad2: Default::default(),
+        }
+    }
+
+    /// Default INIT2 values for SEV-SNP
+    pub fn init_default_snp() -> Self {
+        Self {
+            vmsa_features: 0,
+            flags: 0,
+            ghcb_version: 2,
+            pad1: Default::default(),
+            pad2: Default::default(),
+        }
+    }
+}

--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -9,7 +9,7 @@ use crate::error::{Error::InvalidLen, Indeterminate};
 #[cfg(target_os = "linux")]
 use crate::launch::linux::ioctl::*;
 #[cfg(target_os = "linux")]
-use crate::launch::linux::sev::*;
+use crate::launch::linux::{sev::*, shared::*};
 use crate::*;
 
 use std::convert::TryFrom;
@@ -56,8 +56,12 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<New, U, V> {
             state: New,
         };
 
-        let mut cmd = Command::from(&launcher.sev, &Init);
-        INIT.ioctl(&mut launcher.vm_fd, &mut cmd)
+        let init = Init2::init_default_sev();
+
+        let mut cmd = Command::from(&launcher.sev, &init);
+
+        INIT2
+            .ioctl(&mut launcher.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
 
         Ok(launcher)
@@ -71,8 +75,10 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<New, U, V> {
             state: New,
         };
 
-        let mut cmd = Command::from(&launcher.sev, &EsInit);
-        ES_INIT
+        let init = Init2::init_default_es();
+
+        let mut cmd = Command::from(&launcher.sev, &init);
+        INIT2
             .ioctl(&mut launcher.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
 

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -31,6 +31,9 @@ const CODE: &[u8; 16] = &[
 #[test]
 #[serial]
 fn sev() {
+    // KVM SEV type
+    const KVM_X86_SEV_VM: u64 = 2;
+
     let mut sev = Firmware::open().unwrap();
     let build = sev.platform_status().unwrap().build;
     let chain = cached_chain::get().expect(
@@ -43,7 +46,9 @@ fn sev() {
     let start = session.start(chain).unwrap();
 
     let kvm = Kvm::new().unwrap();
-    let vm = kvm.create_vm().unwrap();
+
+    // Create VMft with SEV type
+    let vm = kvm.create_vm_with_type(KVM_X86_SEV_VM).unwrap();
 
     // Allocate a 1kB page of memory for the address space of the VM.
     const MEM_SIZE: usize = 0x1000;


### PR DESCRIPTION
Updated the launch library to use INIT2 IOCTL and deprecate the old INIT IOCTLs. Created new functions to register encrypted memory for SNP. Updated SEV test to use INIT2. Updated the SNP launch test to use GMEM and support KVM GMEM for launch.